### PR TITLE
Unit-tests for producer with strategist

### DIFF
--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -263,11 +263,31 @@ class Experiment(object):
         trial.status = 'completed'
         self._db.write('trials', trial.to_dict(), query={'_id': trial.id})
 
+    def register_lie(self, lying_trial):
+        """Register in database a *fake* trial created by a strategist object.
+
+        The main difference between fake trial and orignal ones is the addition of a fake objective
+        result, and status being set to completed. The id of the fake trial is different than the id
+        of the original trial, but the original id can be computed using the hashcode on parameters
+        of the fake trial. See mod:`orion.core.worker.strategy` for more information and the
+        Strategist object and generation of fake trials.
+
+        :type lying_trial: `Trial` object
+        """
+        try:
+            # TODO: Test that lying trial have experiment id of current experiment or in the
+            #       Experiment Version Control Tree?
+            lying_trial.status = 'completed'
+            lying_trial.end_time = datetime.datetime.utcnow()
+            self._db.write('lying_trials', lying_trial.to_dict())
+        except DuplicateKeyError:
+            pass
+
     def register_trial(self, trial):
         """Inform database about *new* suggested trial with specific parameter
         values. Each of them correspond to a different possible run.
 
-        :type trials: list of `Trial`
+        :type trial: `Trial` object
         """
         try:
             stamp = datetime.datetime.utcnow()

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -298,17 +298,21 @@ class Experiment(object):
 
         return completed_trials
 
-    def fetch_active_trials(self):
-        """Fetch currently incomplete trials for this `Experiment`
+    def fetch_noncompleted_trials(self):
+        """Fetch non-completed trials of this `Experiment` instance.
 
-        :return: list of incomplete `Trial` objects
+        .. note::
+
+            It will return all non-completed trials, including new, reserved, suspended,
+            interruped and broken ones.
+
+        :return: list of non-completed `Trial` objects
         """
-        # TODO(mnoukhov): add reserved to query?
         query = dict(
-            status={'$in': ['new', 'interrupted']}
-        )
-        active_trials = self.fetch_trials_tree(query)
-        return active_trials
+            status={'$ne': 'completed'}
+            )
+
+        return self.fetch_trials_tree(query)
 
     # pylint: disable=invalid-name
     @property

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -75,13 +75,13 @@ class Producer(object):
             self.algorithm.observe(points, results)
             self.strategy.observe(points, results)
 
-    def _produces_lies(self):
+    def _produce_lies(self):
         """Add fake objective results to incomplete trials
 
         Then register the trials in the db
         """
         log.debug("### Fetch active trials to observe:")
-        incomplete_trials = self.experiment.fetch_active_trials()
+        incomplete_trials = self.experiment.fetch_noncompleted_trials()
         lying_trials = []
         log.debug("### %s", incomplete_trials)
 
@@ -101,7 +101,7 @@ class Producer(object):
         """Pull all non completed trials to update naive model."""
         self.naive_algorithm = copy.deepcopy(self.algorithm)
         log.debug("### Create fake trials to observe:")
-        lying_trials = self._produces_lies()
+        lying_trials = self._produce_lies()
         log.debug("### %s", lying_trials)
         if lying_trials:
             log.debug("### Convert them to list of points and their results.")

--- a/src/orion/core/worker/producer.py
+++ b/src/orion/core/worker/producer.py
@@ -93,7 +93,7 @@ class Producer(object):
                 lying_trial.results.append(lying_result)
                 lying_trials.append(lying_trial)
                 log.debug("### Register lie to database: %s", lying_trial)
-                self.experiment.register_trial(lying_trial)
+                self.experiment.register_lie(lying_trial)
 
         return lying_trials
 

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -261,7 +261,10 @@ class Trial(object):
         if not self.params and not self.experiment:
             raise ValueError("Cannot distinguish this trial, as 'params' or 'experiment' "
                              "have not been set.")
-        return hashlib.md5((self.params_repr() + str(self.experiment)).encode('utf-8')).hexdigest()
+        params_repr = self.params_repr()
+        experiment_repr = str(self.experiment)
+        lie_repr = self._repr_values([self.lie]) if self.lie else ""
+        return hashlib.md5((params_repr + experiment_repr + lie_repr).encode('utf-8')).hexdigest()
 
     def __hash__(self):
         """Return the hashname for this trial"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,7 @@ def clean_db(database, exp_config):
     """Clean insert example experiment entries to collections."""
     database.experiments.drop()
     database.experiments.insert_many(exp_config[0])
+    database.lying_trials.drop()
     database.trials.drop()
     database.trials.insert_many(exp_config[1])
     database.workers.drop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,13 @@ class DumbAlgo(BaseAlgorithm):
         """Configure returns, allow for variable variables."""
         self._times_called_suspend = 0
         self._times_called_is_done = 0
-        self._num = None
-        self._points = None
-        self._results = None
+        self._num = 0
+        self._points = []
+        self._results = []
         self._score_point = None
         self._judge_point = None
         self._measurements = None
+        self.possible_values = [value]
         super(DumbAlgo, self).__init__(space, value=value,
                                        scoring=scoring, judgement=judgement,
                                        suspend=suspend,
@@ -38,13 +39,25 @@ class DumbAlgo(BaseAlgorithm):
 
     def suggest(self, num=1):
         """Suggest based on `value`."""
-        self._num = num
-        return [self.value] * num
+        self._num += num
+
+        rval = []
+        while len(rval) < num:
+            if len(self.possible_values) > 1:
+                value = self.possible_values.pop(0)
+            else:
+                value = self.possible_values[0]
+
+            rval.append(value)
+
+        self._suggested = rval
+
+        return rval
 
     def observe(self, points, results):
         """Log inputs."""
-        self._points = points
-        self._results = results
+        self._points += points
+        self._results += results
 
     def score(self, point):
         """Log and return stab."""
@@ -79,6 +92,14 @@ OptimizationAlgorithm.typenames.append(DumbAlgo.__name__.lower())
 def dumbalgo():
     """Return stab algorithm class."""
     return DumbAlgo
+
+
+@pytest.fixture()
+def categorical_values():
+    """Return a list of all the categorical points possible for `supernaedo2` and `supernaedo3`"""
+    return [('rnn', 'rnn'), ('rnn', 'lstm_with_attention'), ('rnn', 'gru'),
+            ('gru', 'rnn'), ('gru', 'lstm_with_attention'), ('gru', 'gru'),
+            ('lstm', 'rnn'), ('lstm', 'lstm_with_attention'), ('lstm', 'gru')]
 
 
 @pytest.fixture()

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -531,7 +531,7 @@
       value: gru
     - name: /decoding_layer
       type: categorical
-      value: gru
+      value: lstm_with_attention
 - experiment: supernaedo2
 
   status: new
@@ -549,7 +549,7 @@
       value: gru
     - name: /decoding_layer
       type: categorical
-      value: lstm_with_attention
+      value: rnn
 - experiment: supernaedo2
 
   status: new  # new, reserved, suspended, completed, broken

--- a/tests/unittests/core/test_primary_algo.py
+++ b/tests/unittests/core/test_primary_algo.py
@@ -60,7 +60,7 @@ class TestPrimaryAlgoWraps(object):
         """Suggest wraps suggested."""
         assert palgo.suggest() == [fixed_suggestion]
         assert palgo.suggest(4) == [fixed_suggestion] * 4
-        palgo.algorithm.value = (5,)
+        palgo.algorithm.possible_values = [(5,)]
         with pytest.raises(AssertionError):
             palgo.suggest()
 

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -319,6 +319,39 @@ def test_naive_algo_trained_on_all_non_completed_trials(producer, database, rand
     assert len(producer.naive_algorithm.algorithm._points) == (1 + 6)
 
 
+def test_naive_algo_is_discared(producer, database, monkeypatch):
+    """Verify that naive algo is discarded and recopied from original algo"""
+
+    # Get rid of the mock on datetime.datetime.utcnow() otherwise fetch_completed_trials always
+    # fetch all trials since _last_fetched never changes.
+    monkeypatch.undo()
+
+    # Set values for predictions
+    producer.experiment.pool_size = 1
+    producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru')]
+
+    producer.update()
+    assert len(producer._produce_lies()) == 4
+
+    first_naive_algorithm = producer.naive_algorithm
+
+    assert len(producer.algorithm.algorithm._points) == 3
+    assert len(first_naive_algorithm.algorithm._points) == (3 + 4)
+
+    producer.produce()
+
+    # Only update the original algo, naive algo is still not discarded
+    producer._update_algorithm()
+    assert len(producer.algorithm.algorithm._points) == 3
+    assert first_naive_algorithm == producer.naive_algorithm
+    assert len(producer.naive_algorithm.algorithm._points) == (3 + 4)
+
+    # Discard naive algo and create a new one, now trained on 5 points.
+    producer._update_naive_algorithm()
+    assert first_naive_algorithm != producer.naive_algorithm
+    assert len(producer.naive_algorithm.algorithm._points) == (3 + 5)
+
+
 @pytest.mark.skip(reason="Waiting for rebase on non-blocking design PR...")
 def test_concurent_producers(producer, database, random_dt):
     """Test concurrent production of new trials."""

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Collection of tests for :mod:`orion.core.worker.producer`."""
+import copy
+
 import pytest
 
 from orion.core.worker.producer import Producer
@@ -10,16 +12,23 @@ from orion.core.worker.producer import Producer
 def producer(hacked_exp, random_dt, exp_config):
     """Return a setup `Producer`."""
     # make init done
+
+    # TODO: Remove this commented out if test pass
+    # hacked_exp.configure(exp_config[0][3])
+    # # insert fake point
+    # fake_point = ('gru', 'rnn')
+    # assert fake_point in hacked_exp.space
+    # hacked_exp.algorithms.algorithm.value = fake_point
+
     hacked_exp.configure(exp_config[0][3])
-    # insert fake point
-    fake_point = ('gru', 'rnn')
-    assert fake_point in hacked_exp.space
-    hacked_exp.algorithms.algorithm.value = fake_point
+    hacked_exp.pool_size = 1
+    hacked_exp.algorithms.algorithm.possible_values = categorical_values
     return Producer(hacked_exp)
 
 
-def test_update(producer):
-    """Test functionality of producer.update()."""
+def test_algo_observe_completed(producer):
+    """Test that algo only observes completed trials"""
+    assert len(producer.experiment.fetch_trials({})) > 3
     producer.update()
     # Algorithm must have received completed points and their results
     obs_points = producer.algorithm.algorithm._points
@@ -27,7 +36,7 @@ def test_update(producer):
     assert len(obs_points) == 3
     assert obs_points[0] == ('lstm', 'rnn')
     assert obs_points[1] == ('rnn', 'rnn')
-    assert obs_points[2] == ('gru', 'gru')
+    assert obs_points[2] == ('gru', 'lstm_with_attention')
     assert len(obs_results) == 3
     assert obs_results[0] == {
         'objective': 3,
@@ -44,7 +53,6 @@ def test_update(producer):
         'gradient': (5, 3),
         'constraint': [1.2]
         }
-
 
 @pytest.mark.skip(reason="To be implemented...")
 def test_update_algorithm(producer):
@@ -75,6 +83,9 @@ def test_update_and_produce(producer, database, random_dt):
     """Test functionality of producer.produce()."""
     trials_in_db_before = database.trials.count()
     new_trials_in_db_before = database.trials.count({'status': 'new'})
+
+    producer.experiment.pool_size = 1
+    producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru')]
 
     producer.update()
     producer.produce()
@@ -111,3 +122,167 @@ def test_update_and_produce(producer, database, random_dt):
          'type': 'categorical',
          'value': 'gru'}
         ]
+
+
+def test_concurent_producers(producer, database, random_dt):
+    """Test concurrent production of new trials."""
+    trials_in_db_before = database.trials.count()
+    new_trials_in_db_before = database.trials.count({'status': 'new'})
+
+    # Set so that first producer's algorithm generate valid point on first time
+    # And second producer produce same point and thus must produce next one two.
+    # Hence, we know that producer algo will have _num == 1 and
+    # second producer algo will have _num == 2
+    producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru'), ('gru', 'gru')]
+
+    assert producer.experiment.pool_size == 1
+
+    second_producer = Producer(producer.experiment)
+    second_producer.algorithm = copy.deepcopy(producer.algorithm)
+
+    producer.update()
+    second_producer.update()
+
+    producer.produce()
+    second_producer.produce()
+
+    # Algorithm was required to suggest some trials
+    num_new_points = producer.algorithm.algorithm._num
+    assert num_new_points == 1  # pool size
+    num_new_points = second_producer.algorithm.algorithm._num
+    assert num_new_points == 2  # pool size
+
+    # `num_new_points` new trials were registered at database
+    assert database.trials.count() == trials_in_db_before + 2
+    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
+    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
+    assert new_trials[0]['experiment'] == producer.experiment.name
+    assert new_trials[0]['start_time'] is None
+    assert new_trials[0]['end_time'] is None
+    assert new_trials[0]['results'] == []
+    assert new_trials[0]['params'] == [
+        {'name': '/encoding_layer',
+         'type': 'categorical',
+         'value': 'rnn'},
+        {'name': '/decoding_layer',
+         'type': 'categorical',
+         'value': 'gru'}
+        ]
+
+    assert new_trials[1]['params'] == [
+        {'name': '/encoding_layer',
+         'type': 'categorical',
+         'value': 'gru'},
+        {'name': '/decoding_layer',
+         'type': 'categorical',
+         'value': 'gru'}
+        ]
+
+
+@pytest.mark.skip(reason="Waiting for rebase on non-blocking design PR...")
+def test_duplicate_within_pool(producer, database, random_dt):
+    """Test that an algo suggesting multiple points can have a few registered even
+    if one of them is a duplicate.
+    """
+    trials_in_db_before = database.trials.count()
+    new_trials_in_db_before = database.trials.count({'status': 'new'})
+
+    producer.experiment.pool_size = 2
+
+    producer.experiment.algorithms.algorithm.possible_values = [
+        ('rnn', 'gru'), ('rnn', 'gru'), ('gru', 'gru')]
+
+    producer.update()
+    producer.produce()
+
+    # Algorithm was required to suggest some trials
+    num_new_points = producer.algorithm.algorithm._num
+    assert num_new_points == 4  # 2 * pool size
+
+    # `num_new_points` new trials were registered at database
+    assert database.trials.count() == trials_in_db_before + 2
+    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
+    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
+    assert new_trials[0]['experiment'] == producer.experiment.name
+    assert new_trials[0]['start_time'] is None
+    assert new_trials[0]['end_time'] is None
+    assert new_trials[0]['results'] == []
+    assert new_trials[0]['params'] == [
+        {'name': '/encoding_layer',
+         'type': 'categorical',
+         'value': 'rnn'},
+        {'name': '/decoding_layer',
+         'type': 'categorical',
+         'value': 'gru'}
+        ]
+
+    assert new_trials[1]['params'] == [
+        {'name': '/encoding_layer',
+         'type': 'categorical',
+         'value': 'gru'},
+        {'name': '/decoding_layer',
+         'type': 'categorical',
+         'value': 'gru'}
+        ]
+
+
+@pytest.mark.skip(reason="Waiting for rebase on non-blocking design PR...")
+def test_duplicate_within_pool_and_db(producer, database, random_dt):
+    """Test that an algo suggesting multiple points can have a few registered even
+    if one of them is a duplicate with db.
+    """
+    trials_in_db_before = database.trials.count()
+    new_trials_in_db_before = database.trials.count({'status': 'new'})
+
+    producer.experiment.pool_size = 2
+
+    producer.experiment.algorithms.algorithm.possible_values = [
+        ('rnn', 'gru'), ('rnn', 'rnn'), ('gru', 'gru')]
+
+    producer.update()
+    producer.produce()
+
+    # Algorithm was required to suggest some trials
+    num_new_points = producer.algorithm.algorithm._num
+    assert num_new_points == 4  # pool size
+
+    # `num_new_points` new trials were registered at database
+    assert database.trials.count() == trials_in_db_before + 2
+    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
+    new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
+    assert new_trials[0]['experiment'] == producer.experiment.name
+    assert new_trials[0]['start_time'] is None
+    assert new_trials[0]['end_time'] is None
+    assert new_trials[0]['results'] == []
+    assert new_trials[0]['params'] == [
+        {'name': '/encoding_layer',
+         'type': 'categorical',
+         'value': 'rnn'},
+        {'name': '/decoding_layer',
+         'type': 'categorical',
+         'value': 'gru'}
+        ]
+
+    assert new_trials[1]['params'] == [
+        {'name': '/encoding_layer',
+         'type': 'categorical',
+         'value': 'gru'},
+        {'name': '/decoding_layer',
+         'type': 'categorical',
+         'value': 'gru'}
+        ]
+
+
+@pytest.mark.skip(reason="Waiting for rebase on non-blocking design PR...")
+def test_exceed_max_attempts(producer, database, random_dt):
+    """Test that RuntimeError is raised when algo keep suggesting the same points"""
+    producer.max_attempts = 10  # to limit run-time, default would work as well.
+    producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'rnn')]
+
+    assert producer.experiment.pool_size == 1
+
+    producer.update()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        producer.produce()
+    assert "Looks like the algorithm keeps suggesting" in str(exc_info.value)

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -168,6 +168,77 @@ def test_register_new_trials(producer, database, random_dt):
         ]
 
 
+def test_no_lies_if_all_trials_completed(producer, database, random_dt):
+    """Verify that no lies are created if all trials are completed"""
+    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    database.trials.remove(query)
+    trials_in_db_before = database.trials.count({'experiment': producer.experiment.id})
+    assert trials_in_db_before == 3
+
+    producer.update()
+
+    assert len(producer._produce_lies()) == 0
+
+
+def test_lies_generation(producer, database, random_dt):
+    """Verify that lies are created properly"""
+    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    trials_non_completed = list(database.trials.find(query))
+    assert len(trials_non_completed) == 4
+
+    producer.update()
+
+    lies = producer._produce_lies()
+    assert len(lies) == 4
+
+    for i in range(4):
+        trials_non_completed[i]['_id'] = lies[i].id
+        trials_non_completed[i]['status'] = 'completed'
+        trials_non_completed[i]['end_time'] = random_dt
+        trials_non_completed[i]['results'].append(producer.strategy._lie.to_dict())
+        assert lies[i].to_dict() == trials_non_completed[i]
+
+
+def test_naive_algo_not_trained_when_all_trials_completed(producer, database, random_dt):
+    """Verify that naive algo is not trained on additional trials when all completed"""
+    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    database.trials.remove(query)
+    trials_in_db_before = database.trials.count({'experiment': producer.experiment.id})
+    assert trials_in_db_before == 3
+
+    producer.update()
+
+    assert len(producer.algorithm.algorithm._points) == 3
+    assert len(producer.naive_algorithm.algorithm._points) == 3
+
+
+def test_naive_algo_trained_on_all_non_completed_trials(producer, database, random_dt):
+    """Verify that naive algo is trained on additional trials"""
+    # Set two of completed trials to broken and reserved to have all possible status
+    query = {'status': 'completed', 'experiment': producer.experiment.id}
+    completed_trials = database.trials.find(query)
+    database.trials.update({'_id': completed_trials[0]['_id']}, {'$set': {'status': 'broken'}})
+    database.trials.update({'_id': completed_trials[1]['_id']}, {'$set': {'status': 'reserved'}})
+
+    # Make sure non completed trials and completed trials are set properly for the unit-test
+    query = {'status': {'$ne': 'completed'}, 'experiment': producer.experiment.id}
+    non_completed_trials = list(database.trials.find(query))
+    assert len(non_completed_trials) == 6
+    # Make sure we have all type of status except completed
+    assert (set(trial['status'] for trial in non_completed_trials) ==
+            set(['new', 'reserved', 'suspended', 'interrupted', 'broken']))
+    query = {'status': 'completed', 'experiment': producer.experiment.id}
+    assert database.trials.count(query) == 1
+
+    # Executing the actual test
+    producer.update()
+    assert len(producer._produce_lies()) == 6
+
+    assert len(producer.algorithm.algorithm._points) == 1
+    assert len(producer.naive_algorithm.algorithm._points) == (1 + 6)
+
+
+@pytest.mark.skip(reason="Waiting for rebase on non-blocking design PR...")
 def test_concurent_producers(producer, database, random_dt):
     """Test concurrent production of new trials."""
     trials_in_db_before = database.trials.count()

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -6,10 +6,31 @@ import copy
 import pytest
 
 from orion.core.worker.producer import Producer
+from orion.core.worker.trial import Trial
+
+
+class DumbParallelStrategy:
+    """Mock object for parallel strategy"""
+
+    def observe(self, points, results):
+        """See BaseParallelStrategy.observe"""
+        self._observed_points = points
+        self._observed_results = results
+        self._value = None
+
+    def lie(self, trial):
+        """See BaseParallelStrategy.lie"""
+        if self._value:
+            value = self._value
+        else:
+            value = len(self._observed_points)
+
+        self._lie = lie = Trial.Result(name='lie', type='lie', value=value)
+        return lie
 
 
 @pytest.fixture()
-def producer(hacked_exp, random_dt, exp_config):
+def producer(hacked_exp, random_dt, exp_config, categorical_values, monkeypatch):
     """Return a setup `Producer`."""
     # make init done
 
@@ -23,6 +44,9 @@ def producer(hacked_exp, random_dt, exp_config):
     hacked_exp.configure(exp_config[0][3])
     hacked_exp.pool_size = 1
     hacked_exp.algorithms.algorithm.possible_values = categorical_values
+
+    hacked_exp.producer['strategy'] = DumbParallelStrategy()
+
     return Producer(hacked_exp)
 
 
@@ -54,33 +78,65 @@ def test_algo_observe_completed(producer):
         'constraint': [1.2]
         }
 
-@pytest.mark.skip(reason="To be implemented...")
-def test_update_algorithm(producer):
-    """Test functionality of _update_algorithm."""
-    pass
+
+def test_strategist_observe_completed(producer):
+    """Test that strategist only observes completed trials"""
+    assert len(producer.experiment.fetch_trials({})) > 3
+    producer.update()
+    # Algorithm must have received completed points and their results
+    obs_points = producer.strategy._observed_points
+    obs_results = producer.strategy._observed_results
+    assert len(obs_points) == 3
+    assert obs_points[0] == ('lstm', 'rnn')
+    assert obs_points[1] == ('rnn', 'rnn')
+    assert obs_points[2] == ('gru', 'lstm_with_attention')
+    assert len(obs_results) == 3
+    assert obs_results[0] == {
+        'objective': 3,
+        'gradient': None,
+        'constraint': []
+        }
+    assert obs_results[1] == {
+        'objective': 2,
+        'gradient': (-0.1, 2),
+        'constraint': []
+        }
+    assert obs_results[2] == {
+        'objective': 10,
+        'gradient': (5, 3),
+        'constraint': [1.2]
+        }
 
 
-@pytest.mark.skip(reason="To be implemented...")
-def test_update_naive_algorithm(producer):
-    """Test functionality of _update_naive_algorithm."""
-    pass
+def test_naive_algorithm_is_producing(producer, database, random_dt):
+    """Verify naive algo is used to produce, not original algo"""
+    producer.experiment.pool_size = 1
+    producer.experiment.algorithms.algorithm.possible_values = [('rnn', 'gru')]
+    producer.update()
+    producer.produce()
+
+    assert producer.naive_algorithm.algorithm._num == 1  # pool size
+    assert producer.algorithm.algorithm._num == 0
 
 
-@pytest.mark.skip(reason="To be implemented...")
-def test_producing_lies(producer):
-    """Test functionality of _produce_lies with a strategy."""
-    pass
-
-
-@pytest.mark.skip(reason="To be implemented...")
-def test_producing_no_lies(producer):
-    """Test functionality of _produce_lies with NoParallelStrategy."""
-    pass
-
-
-@pytest.mark.skip(reason="DumbAlgo generates duplicate trials")
 def test_update_and_produce(producer, database, random_dt):
-    """Test functionality of producer.produce()."""
+    """Test new trials are properly produced"""
+    possible_values = [('rnn', 'gru')]
+    producer.experiment.pool_size = 1
+    producer.experiment.algorithms.algorithm.possible_values = possible_values
+
+    producer.update()
+    producer.produce()
+
+    # Algorithm was ordered to suggest some trials
+    num_new_points = producer.naive_algorithm.algorithm._num
+    assert num_new_points == 1  # pool size
+
+    assert producer.naive_algorithm.algorithm._suggested == possible_values
+
+
+def test_register_new_trials(producer, database, random_dt):
+    """Test new trials are properly registered"""
     trials_in_db_before = database.trials.count()
     new_trials_in_db_before = database.trials.count({'status': 'new'})
 
@@ -91,12 +147,12 @@ def test_update_and_produce(producer, database, random_dt):
     producer.produce()
 
     # Algorithm was ordered to suggest some trials
-    num_new_points = producer.algorithm.algorithm._num
-    assert num_new_points == 2  # pool size
+    num_new_points = producer.naive_algorithm.algorithm._num
+    assert num_new_points == 1  # pool size
 
     # `num_new_points` new trials were registered at database
-    assert database.trials.count() == trials_in_db_before + 2
-    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 2
+    assert database.trials.count() == trials_in_db_before + 1
+    assert database.trials.count({'status': 'new'}) == new_trials_in_db_before + 1
     new_trials = list(database.trials.find({'status': 'new', 'submit_time': random_dt}))
     assert new_trials[0]['experiment'] == producer.experiment.name
     assert new_trials[0]['start_time'] is None
@@ -105,19 +161,7 @@ def test_update_and_produce(producer, database, random_dt):
     assert new_trials[0]['params'] == [
         {'name': '/encoding_layer',
          'type': 'categorical',
-         'value': 'lstm'},
-        {'name': '/decoding_layer',
-         'type': 'categorical',
-         'value': 'gru'}
-        ]
-    assert new_trials[1]['experiment'] == producer.experiment.name
-    assert new_trials[1]['start_time'] is None
-    assert new_trials[1]['end_time'] is None
-    assert new_trials[1]['results'] == []
-    assert new_trials[1]['params'] == [
-        {'name': '/encoding_layer',
-         'type': 'categorical',
-         'value': 'lstm'},
+         'value': 'rnn'},
         {'name': '/decoding_layer',
          'type': 'categorical',
          'value': 'gru'}

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -113,7 +113,7 @@ class TestTrial(object):
         t = Trial(**exp_config[1][2])
         assert str(t) == "Trial(experiment='supernaedo2', status='completed',\n"\
                          "      params=/encoding_layer:gru\n"\
-                         "             /decoding_layer:gru)"
+                         "             /decoding_layer:lstm_with_attention)"
 
     def test_str_value(self, exp_config):
         """Test representation of `Trial.Value`."""
@@ -176,8 +176,8 @@ class TestTrial(object):
     def test_params_repr_property(self, exp_config):
         """Check property `Trial.params_repr`."""
         t = Trial(**exp_config[1][2])
-        assert t.params_repr() == "/encoding_layer:gru,/decoding_layer:gru"
-        assert t.params_repr(sep='\n') == "/encoding_layer:gru\n/decoding_layer:gru"
+        assert t.params_repr() == "/encoding_layer:gru,/decoding_layer:lstm_with_attention"
+        assert t.params_repr(sep='\n') == "/encoding_layer:gru\n/decoding_layer:lstm_with_attention"
 
         t = Trial()
         assert t.params_repr() == ""
@@ -185,7 +185,7 @@ class TestTrial(object):
     def test_hash_name_property(self, exp_config):
         """Check property `Trial.hash_name`."""
         t = Trial(**exp_config[1][2])
-        assert t.hash_name == "aff5de14d4540bb3ad4fe0526411ea0d"
+        assert t.hash_name == "af737340845fb882e625d119968fd922"
 
         t = Trial()
         with pytest.raises(ValueError) as exc:
@@ -195,7 +195,7 @@ class TestTrial(object):
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""
         t = Trial(**exp_config[1][2])
-        assert t.full_name == ".encoding_layer:gru-.decoding_layer:gru"
+        assert t.full_name == ".encoding_layer:gru-.decoding_layer:lstm_with_attention"
 
         t = Trial()
         with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
### Add unit-tests for the producer.

- produce()
    - Test that new point comes from naive_algorithm, not algorithm
    - Test that trial is successfully registered only if new

- _update_algorithm
    - Test that algo is updated on completed trials
    - Test that strategy is updated on completed trials

- _produces_lies
    - Test that no lies are produced if all trials are completed
    - Test that lies are created properly
    - Test that lies are integrated in DB properly (separate collection)
    - Test that duplicate lies end up as the same one in DB
    - Test that duplicate with different lie value gets different spot in the DB

- _update_naive_algorithm
    - Test that naive algo is not trained if all trials are completed
    - Test naive algo is trained on new, interrupted, suspended and broken trials
    - Test naive algo is discarded and copied from up-to-date algo

----- 

### Minor modifications

- Add Experiment.register_lie() in 504fdd3
- Add trial hashing on lie results in 504fdd3
- Turn fetch_active_trials into fetch_noncompleted_trials in db83d4c
